### PR TITLE
Add status indicators for web scrapers

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Auth;
 use App\TaxInfo;
 use Illuminate\Http\Request;
+use \App\Http\Controllers\TaxInfoController;
 
 class HomeController extends Controller
 {
@@ -14,11 +15,14 @@ class HomeController extends Controller
         if( Auth::guest() ) {
             return view('login.login');
         }else{
-            $scraped = TaxInfo::where('status', '>', 0)->count();
-            $properties = TaxInfo::count();
-            $progress = round( ((100 / $properties) * $scraped), 2);
 
-            return view('welcome', ['progress' => $progress]);
+            $latestBatch = TaxInfoController::getLatestBatchNumber();
+            $parcelsInBatch = TaxInfo::where('batch_id', $latestBatch)->count();
+            $scrapedParcels = TaxInfo::where('batch_id', $latestBatch)->where('status', '!=', 0)->count();
+            $data['percentScraped'] = round( (100 / $parcelsInBatch) * $scrapedParcels , 2);
+            $data['latestBatch'] = $latestBatch;
+
+            return view('welcome', $data);
         }
     }
 

--- a/app/Http/Controllers/TaxInfoController.php
+++ b/app/Http/Controllers/TaxInfoController.php
@@ -66,7 +66,7 @@ class TaxInfoController extends Controller
     *
     * @return Integer
     */
-    private function getLatestBatchNumber()
+    public static function getLatestBatchNumber()
     {
         $lastBatchId = TaxInfo::select('batch_id')->orderBy('batch_id', 'DESC')->first();
         return intval($lastBatchId->batch_id);

--- a/app/Http/Controllers/TaxInfoController.php
+++ b/app/Http/Controllers/TaxInfoController.php
@@ -17,6 +17,12 @@ class TaxInfoController extends Controller
      */
     public function index()
     {
+        $latestBatch = $this->getLatestBatchNumber();
+        $parcelsInBatch = TaxInfo::where('batch_id', $latestBatch)->count();
+        $scrapedParcels = TaxInfo::where('batch_id', $latestBatch)->where('status', '!=', 0)->count();
+
+        $data['percentScraped'] = round( (100 / $parcelsInBatch) * $scrapedParcels , 2);
+
         $data['parcels'] = TaxInfo::where('status', 1)
             ->where('batch_id', $this->getLatestBatchNumber())
             ->where('property_class', 'R - Residential')

--- a/resources/views/tax-info/index.blade.php
+++ b/resources/views/tax-info/index.blade.php
@@ -4,13 +4,25 @@
 
 <div class="row">
     <div class="col-sm-8">
-        <h1>Tax Information</h1>
+        <h1 class="d-inline">Tax Information</h1>
+        @if($percentScraped == 100)
+            <h5 class="d-inline text-muted">- <span class="text-success">Scraper Finished</span></h5>
+        @endif
     </div>
     <div class="col-sm-4">
         <a href="{{ route('tax-info.export')           }}" class="btn btn-outline-secondary btn-lg float-sm-right d-block d-sm-inline mt-2 ml-4">EXPORT</a>
         <a href="{{ route('tax-info.parcel-id.upload') }}" class="btn btn-outline-success   btn-lg float-sm-right d-block d-sm-inline mt-2 ml-4">UPLOAD</a>
     </div>
 </div>
+
+@if($percentScraped < 100)
+<div class="col-10 offset-1 mt-4 mb-3">
+    <h5 class="font-weight-light">Data Scraper Currently Running <small>- {{$percentScraped}}% Complete</small></h5>
+    <div class="progress">
+        <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="{{$percentScraped}}" aria-valuemin="0" aria-valuemax="100" style="width: {{$percentScraped}}%"></div>
+    </div>
+</div>
+@endif
 
 
 <div class="table-responsive">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,24 +2,38 @@
 
 @section('content')
 
-<br><br>
-<h1 class="text-center">Welcome</h1>
-
-<div class="row">
-    <div class="col-sm-10 offset-sm-1">
-    <h2>
-        Auditor Scraper Progress
-        <small class="text-muted">({{ $progress }}%)</small>
-    </h2>
-        <div class="progress">
-            <div
-                class="progress-bar progress-bar-striped progress-bar-animated"
-                role="progressbar"
-                style="width: {{ $progress }}%"
-                aria-valuenow="{{ $progress }}"
-                aria-valuemin="0"
-                aria-valuemax="100"
-            ></div>
+<div class="card-deck mb-3 text-center">
+    <div class="card mb-4 shadow-sm border-danger">
+        <div class="card-header bg-danger">
+            <h4 class="my-0 font-weight-normal text-white">Municipal Court</h4>
+        </div>
+        <div class="card-body text-muted">
+            <h1 class="card-title">N/A</h1>
+            <h4>Court Case scraper needs to be rewritten</h4>
+        </div>
+    </div>
+    <div class="card mb-4 shadow-sm">
+        <div class="card-header">
+            <h4 class="my-0 font-weight-normal">Tax Delinquency Info</h4>
+        </div>
+        <div class="card-body">
+            <h4>Batch #{{$latestBatch}} of Parcel IDs has been imported</h4>
+            <h5>
+                @if($percentScraped < 100)
+                    Auditor site scraper is running
+                @else
+                    <span class="text-success">All data has been collected</span>
+                @endif
+            </h5>
+            @if($percentScraped < 100)
+            <div class="col-10 offset-1 mt-4 mb-3">
+                <hr>
+                <div class="progress">
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="{{$percentScraped}}" aria-valuemin="0" aria-valuemax="100" style="width: {{$percentScraped}}%"></div>
+                </div>
+                <p>{{$percentScraped}}% Complete</p>
+            </div>
+            @endif
         </div>
     </div>
 </div>


### PR DESCRIPTION
The status is based on the number of records in the `tax_info` table with a current `batch_id` and a `status` of 0. If there are no 0 values, then the scraper can be considered finished.